### PR TITLE
Switch docs to Postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Before setting up CleverPad, ensure you have the following installed:
 
 2. **Configure environment variables**
    
-   Create a `.env` file in the `backend` directory:
+   Copy `backend/.env.example` to `backend/.env` and update the values as needed:
    ```env
    DATABASE_URL=postgresql://cleverpad_user:your_password@localhost:5432/CleverPad
    SECRET_KEY=your-super-secret-key-here
@@ -166,7 +166,7 @@ CleverPad/
 │   │   ├── database.py        # Database connection
 │   │   └── main.py            # FastAPI application entry point
 │   ├── requirements.txt       # Python dependencies
-│   └── .env                   # Environment variables
+│   └── .env.example                   # Sample environment variables
 ├── 📁 frontend/               # React frontend
 │   ├── 📁 src/
 │   │   ├── 📁 components/     # React components

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,4 @@
+DATABASE_URL=postgresql://cleverpad_user:your_password@localhost:5432/CleverPad
+SECRET_KEY=your-super-secret-key-here
+ALGORITHM=HS256
+ACCESS_TOKEN_EXPIRE_MINUTES=30

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -2,9 +2,7 @@ from pydantic import BaseModel
 from dotenv import load_dotenv
 import os
 
-load_dotenv()  # reads .env
-
-
+load_dotenv()  # load environment variables from .env file
 class Settings(BaseModel):
     database_url: str = os.getenv("DATABASE_URL")
     secret_key: str = os.getenv("SECRET_KEY")


### PR DESCRIPTION
## Summary
- document Postgres environment file
- provide `.env.example` with Postgres URL
- clarify dotenv loading code

## Testing
- `python -m app.main` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6849660e21f88332a2d79855e217d00c